### PR TITLE
Updated GSVA support

### DIFF
--- a/R/ConsensusTME.R
+++ b/R/ConsensusTME.R
@@ -197,8 +197,22 @@ geneSetEnrichment <- function(bulkExp, signatures, statMethod = c("ssgsea", "gsv
     }
     consensusEstimates <- singOut
   } else if (statMethod %in% c("ssgsea", "gsva", "plage", "zscore")) {
-    consensusEstimates <- GSVA::gsva(expr = bulkExp, gset.idx.list = signatures, method = statMethod, min.sz = 0, max.sz = dim(bulkExp)[1],
-                                     parallel.sz = parallel.sz, ssgsea.norm = TRUE)
+    if(packageVersion("GSVA") >= "1.50.0"){
+      # Legacy GSVA function was depreciated in version 1.50 and entirely removed in version 1.52.
+      if (statMethod=="ssgsea") {
+        gsvapar <- GSVA::ssgseaParam(exprData = bulkExp, geneSets = signatures, minSize = 0, maxSize = dim(bulkExp)[1], normalize = TRUE)
+      } else if (statMethod=="gsva") {
+        gsvapar <- GSVA::gsvaParam(exprData = bulkExp, geneSets = signatures, minSize = 0, maxSize = dim(bulkExp)[1])
+      } else if (statMethod=="plage") {
+        gsvapar <- GSVA::plageParam(exprData = bulkExp, geneSets = signatures, minSize = 0, maxSize = dim(bulkExp)[1])
+      } else {
+        gsvapar <- GSVA::zscoreParam(exprData = bulkExp, geneSets = signatures, minSize = 0, maxSize = dim(bulkExp)[1])
+      }
+      consensusEstimates <- GSVA::gsva(gsvapar)
+    } else {
+      consensusEstimates <- GSVA::gsva(expr = bulkExp, gset.idx.list = signatures, method = statMethod, min.sz = 0, max.sz = dim(bulkExp)[1],
+                                       parallel.sz = parallel.sz, ssgsea.norm = TRUE)
+    }
   }
 }
 

--- a/R/ConsensusTME.R
+++ b/R/ConsensusTME.R
@@ -198,15 +198,15 @@ geneSetEnrichment <- function(bulkExp, signatures, statMethod = c("ssgsea", "gsv
     consensusEstimates <- singOut
   } else if (statMethod %in% c("ssgsea", "gsva", "plage", "zscore")) {
     if(packageVersion("GSVA") >= "1.50.0"){
-      # Legacy GSVA function was depreciated in version 1.50 and entirely removed in version 1.52.
+      # Legacy GSVA function was depreciated in version 1.50 and entirely removed in version 1.52. (minSize must be 1 or greater)
       if (statMethod=="ssgsea") {
-        gsvapar <- GSVA::ssgseaParam(exprData = bulkExp, geneSets = signatures, minSize = 0, maxSize = dim(bulkExp)[1], normalize = TRUE)
+        gsvapar <- GSVA::ssgseaParam(exprData = bulkExp, geneSets = signatures, minSize = 1, maxSize = dim(bulkExp)[1], normalize = TRUE)
       } else if (statMethod=="gsva") {
-        gsvapar <- GSVA::gsvaParam(exprData = bulkExp, geneSets = signatures, minSize = 0, maxSize = dim(bulkExp)[1])
+        gsvapar <- GSVA::gsvaParam(exprData = bulkExp, geneSets = signatures, minSize = 1, maxSize = dim(bulkExp)[1])
       } else if (statMethod=="plage") {
-        gsvapar <- GSVA::plageParam(exprData = bulkExp, geneSets = signatures, minSize = 0, maxSize = dim(bulkExp)[1])
+        gsvapar <- GSVA::plageParam(exprData = bulkExp, geneSets = signatures, minSize = 1, maxSize = dim(bulkExp)[1])
       } else {
-        gsvapar <- GSVA::zscoreParam(exprData = bulkExp, geneSets = signatures, minSize = 0, maxSize = dim(bulkExp)[1])
+        gsvapar <- GSVA::zscoreParam(exprData = bulkExp, geneSets = signatures, minSize = 1, maxSize = dim(bulkExp)[1])
       }
       consensusEstimates <- GSVA::gsva(gsvapar)
     } else {


### PR DESCRIPTION
The GSVA function was changed in version 1.50, returning a depreciated function warning. With version 1.52 support for the previous way of calling GSVA was removed entirely causing Consensus TME to fail, returning a GSVA error message. This update restores support for newer versions of GSVA.